### PR TITLE
Relaxed opening tag

### DIFF
--- a/lit-element.sublime-syntax
+++ b/lit-element.sublime-syntax
@@ -1054,7 +1054,7 @@ contexts:
 
 
   lit-html:
-    - match: 'html`'
+    - match: \bhtml\b\s?`
       scope: punctuation.section.flowtype.begin
       push: lit-html-body
 


### PR DESCRIPTION
Some (other people's) projects I work on have the opening tag specified with:

html`

and others:

html `

So this little change just allows both.